### PR TITLE
Fixed FileNotFoundError

### DIFF
--- a/f110_utils/nodes/lap_analyser/src/lap_analyser/lap_analyser.py
+++ b/f110_utils/nodes/lap_analyser/src/lap_analyser/lap_analyser.py
@@ -66,7 +66,10 @@ class LapAnalyser:
 
         # Open up logfile
         self.logfile_name = f"lap_analyzer_{datetime.now().strftime('%d%m_%H%M')}.txt"
-        self.logfile_dir = os.path.join(RosPack().get_path('lap_analyser'), 'data', self.logfile_name)
+        self.logfile_par = os.path.join(RosPack().get_path('lap_analyser'), 'data')
+        self.logfile_dir = os.path.join(self.logfile_par, self.logfile_name)
+        if not os.path.exists(self.logfile_par):
+            os.makedirs(self.logfile_par)
         with open(self.logfile_dir, 'w') as f:
             f.write(f"Laps done on " + datetime.now().strftime('%d %b %H:%M:%S') + '\n')
 


### PR DESCRIPTION
If the folder `data` (in which the logfiles are saved) does not yet exist when the lap_analyzer is started, the lap_analyzer  terminates with the error message `FileNotFoundError: [Errno 2] No such file or directory`:

```bash
roslaunch lap_analyser data_analyser.launch
...
Traceback (most recent call last):
  File "/home/user/catkin_ws/src/race_stack/f110_utils/nodes/lap_analyser/src/lap_analyser/data_analyser.py", line 15, in <module>
    lap_analyser = LapAnalyser()
  File "/home/user/catkin_ws/src/race_stack/f110_utils/nodes/lap_analyser/src/lap_analyser/lap_analyser.py", line 70, in __init__
    with open(self.logfile_dir, 'w') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/catkin_ws/src/race_stack/f110_utils/nodes/lap_analyser/data/lap_analyzer_2404_0614.txt'
[data_analyser/data_analyser-1] process has died [pid 6863, exit code 1, cmd /home/user/catkin_ws/src/race_stack/f110_utils/nodes/lap_analyser/src/lap_analyser/data_analyser.py __name:=data_analyser __log:=/home/user/.ros/log/bf6b8858-0201-11ef-8caf-a4bb6d52256b/data_analyser-data_analyser-1.log].
log file: /home/user/.ros/log/bf6b8858-0201-11ef-8caf-a4bb6d52256b/data_analyser-data_analyser-1*.log
all processes on machine have died, roslaunch will exit
shutting down processing monitor...
... shutting down processing monitor complete
done
```