### PR TITLE
Handle invalid scan frames in opponent detector

### DIFF
--- a/perception/abd_tracker/opponent_tracker/src/detect.py
+++ b/perception/abd_tracker/opponent_tracker/src/detect.py
@@ -228,6 +228,9 @@ class Detect :
         """
 
         # --- initialisation of some sutility parameters ---
+        if self.scans is None:
+            return []
+
         l = self.lambda_angle
         d_phi = self.scans.angle_increment
         sigma = self.sigma
@@ -257,8 +260,13 @@ class Detect :
 
         cloudPoints_list = []
         for i in range(xyz_map.shape[1]):
+            if not np.isfinite(xyz_map[0, i]) or not np.isfinite(xyz_map[1, i]):
+                continue
             pt = (xyz_map[0,i], xyz_map[1,i])
             cloudPoints_list.append(pt)
+
+        if not cloudPoints_list:
+            return []
         
         # --------------------------------------------------
         # segment the cloud point into smaller point clouds
@@ -289,7 +297,10 @@ class Detect :
         for obs in objects_pointcloud_list:
             x_points.append(obs[int(len(obs)/2)][0])
             y_points.append(obs[int(len(obs)/2)][1])
-        s_points, d_points = self.converter.get_frenet(np.array(x_points), np.array(y_points))
+        try:
+            s_points, d_points = self.converter.get_frenet(np.array(x_points), np.array(y_points))
+        except ValueError:
+            return []
         
 
         remove_array=[]

--- a/perception/abd_tracker/opponent_tracker/src/detect.py
+++ b/perception/abd_tracker/opponent_tracker/src/detect.py
@@ -260,31 +260,43 @@ class Detect :
 
         cloudPoints_list = []
         for i in range(xyz_map.shape[1]):
-            if not np.isfinite(xyz_map[0, i]) or not np.isfinite(xyz_map[1, i]):
-                continue
             pt = (xyz_map[0,i], xyz_map[1,i])
             cloudPoints_list.append(pt)
 
-        if not cloudPoints_list:
-            return []
-        
         # --------------------------------------------------
         # segment the cloud point into smaller point clouds
         # that represent potential object using the adaptive
         # method
         # --------------------------------------------------
 
-        objects_pointcloud_list = [[[cloudPoints_list[0][0],cloudPoints_list[0][1]]]]
+        objects_pointcloud_list = []
+        prev_point = None
+        prev_idx = None
         for idx, point in enumerate(cloudPoints_list):
-            if (idx == 0):
+            if not np.isfinite(point[0]) or not np.isfinite(point[1]):
                 continue
+            point = [point[0], point[1]]
+            if prev_point is None:
+                objects_pointcloud_list.append([point])
+                prev_point = point
+                prev_idx = idx
+                continue
+
             dist = math.sqrt(point[0]**2 + point[1]**2)
-            d_max = (dist * math.sin(d_phi)/math.sin(l-d_phi)+3*sigma) / 2
-            if (math.dist([cloudPoints_list[idx-1][0],cloudPoints_list[idx-1][1]],
-            [point[0],point[1]])>d_max):
-                objects_pointcloud_list.append([[point[0],point[1]]])
+            angular_gap = (idx - prev_idx) * d_phi
+            if angular_gap >= l:
+                objects_pointcloud_list.append([point])
             else:
-                objects_pointcloud_list[-1].append([point[0],point[1]])
+                d_max = (dist * math.sin(angular_gap)/math.sin(l-angular_gap)+3*sigma) / 2
+                if math.dist(prev_point, point) > d_max:
+                    objects_pointcloud_list.append([point])
+                else:
+                    objects_pointcloud_list[-1].append(point)
+            prev_point = point
+            prev_idx = idx
+
+        if not objects_pointcloud_list:
+            return []
 
         # ------------------------------------------------
         # removing point clouds that are too small or too
@@ -529,6 +541,7 @@ class Detect :
         rate = rospy.Rate(self.rate)
         rospy.loginfo('[Opponent Detection]: Waiting for global wpnts')
         rospy.wait_for_message('/global_waypoints', WpntArray)
+        self.scans = rospy.wait_for_message('/scan', LaserScan)
         rospy.loginfo('[Opponent Detection]: Ready')
         while not rospy.is_shutdown():
             if self.measuring:

--- a/perception/abd_tracker/opponent_tracker/src/detect.py
+++ b/perception/abd_tracker/opponent_tracker/src/detect.py
@@ -299,7 +299,8 @@ class Detect :
             y_points.append(obs[int(len(obs)/2)][1])
         try:
             s_points, d_points = self.converter.get_frenet(np.array(x_points), np.array(y_points))
-        except ValueError:
+        except ValueError as e:
+            rospy.logwarn(f"[Opponent Detection]: Frenet conversion failed in get_frenet: {e}")
             return []
         
 


### PR DESCRIPTION
Avoid crashes in opponent detection when LaserScan data is missing or contains invalid points.

Found an issue of keep hitting the obstacle and touched this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling when sensor scans are missing, avoiding errors and empty outputs.
  * Skips invalid/non-finite scan points to prevent spurious obstacle detections.
  * Stops processing early when no valid objects are found, reducing false reports.
  * Gracefully handles conversion failures with warnings instead of crashes, improving stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForzaETH/race_stack/pull/36)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->